### PR TITLE
inits example docs guidlines and fixes URLs

### DIFF
--- a/docs/content/usage.md
+++ b/docs/content/usage.md
@@ -9,3 +9,26 @@ universal - that is, avoiding lock-in to any particular deployment/devops
 toolchain - the tools provided here may be less featureful or useful 
 than tools that fit polly packages into your existing toolchain 
 (e.g. Terraform, jsonnet/Tanka, flux/2). We'll link to such tools as they evolve.
+
+We appreciate examples submissions, please follow the following guidelines:
+
+1. Explain what's the system under observation (SUO), for example a Kubernetes
+   cluster or a VM or a database.
+1. If you show how to migrate from an existing mixin please link to it.
+
+Other questions to consider:
+
+* What kind of parameters do you think it makes sense for your package to take? Why?
+* How did you decide whether it was worth making particular queries into reusable signals?
+* Which part of the polly spec was most confusing to work with? If you figured it out, what helped you get there?
+* Is there anything about observing the SUO that the polly schema did not allow you to express in the pop?
+
+The PR should contain two parts:
+
+* A dedicated directory under the
+  [examples](https://github.com/pollypkg/polly/tree/main/examples) directory
+  that contains CUE code and any helpers and dependencies.
+* A Markdown file under the [docs
+  content](https://github.com/pollypkg/polly/tree/main/docs/content), you 
+  are encouraged to use [basics.md](https://github.com/pollypkg/polly/blob/main/docs/content/basics.md)
+  as a starting point.

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -1,5 +1,7 @@
 site_name: 'polly'
 site_author: 'polly authors'
+site_url: 'https://pollypkg.github.io/polly/'
+# use_directory_urls: False
 copyright: 'Copyright &copy; polly community 2021'
 repo_name: 'pollypkg/polly'
 repo_url: 'https://github.com/pollypkg/polly/'


### PR DESCRIPTION
This PR contains two things (I know, how cheeky):

1. Adds guidelines to address #24 
2. Fixes the docs URL (due to old `mkdocs` version used previously)