### PR TITLE
[WIP] Handwavy first pass at promql label matcher groups

### DIFF
--- a/examples/basic/node-exporter/node-exporter.cue
+++ b/examples/basic/node-exporter/node-exporter.cue
@@ -1,0 +1,69 @@
+package polly
+
+import "github.com/pollypkg/polly/schema:pollyschema"
+
+// Enforce that the emit value of this file unifies with the Polly schema
+pollyschema.PollyPackage
+
+
+header: {
+	name: "node-exporter"
+	uri:  "github.com/pollypkg/polly/examples/node-exporter"
+	params: {
+		jobval: string | *"node"
+
+		// Select the metrics coming from the node exporter. Note that all
+		// the selected metrics are shown stacked on top of each other in
+		// the 'USE Method / Cluster' dashboard. Consider disabling that
+		// dashboard if mixing up all those metrics in the same dashboard
+		// doesn't make sense (e.g. because they are coming from different
+		// clusters).
+		nodeExporterSelector: ({ job: {
+			Value: jobval
+			Op: "="
+		}} & #SelectorParameterGroup)
+
+		// Select the fstype for filesystem-related queries. If left
+		// empty, all filesystems are selected. If you have unusual
+		// filesystem you don't want to include in dashboards and
+		// alerting, you can exclude them here, e.g. 'fstype!="tmpfs"'.
+		fsSelector: #SelectorParameterGroup | *({ fstype: {
+			Value: ""
+			Op: "!="
+		}} & #SelectorParameterGroup)
+
+		// Select the device for disk-related queries. If left empty, all
+		// devices are selected. If you have unusual devices you don't
+		// want to include in dashboards and alerting, you can exclude
+		// them here, e.g. 'device!="tmpfs"'.
+		diskDeviceSelector: #SelectorParameterGroup | *({ device: {
+			Value: ""
+			Op: "!="
+		}} & #SelectorParameterGroup)
+	}
+}
+
+#SelectorParameter: {
+	Label: string
+	Value: string
+	Op: *"=" | "!=" | "=~" | "!=~"
+}
+
+#SelectorParameterGroup: [L=string]: #SelectorParameter & {
+	Label: L
+}
+
+////////////////////////////////
+// Imagine that the below are in a CUE file written by the consumer of this pop
+
+header: params: jobval: "whooziwhatsit"
+header: params: nodeExporterSelector: {
+	job: {
+		Value: "node"
+		Op: "="
+	}
+	foo: {
+		Value: "bar"
+		Op: "="
+	}
+}


### PR DESCRIPTION
In today's community hack session, i started working on converting the node exporter mixin. Most of the the [config](https://github.com/prometheus/node_exporter/blob/master/docs/node-mixin/config.libsonnet) there is basically creating a framework for letting the user decide which label matchers they want to apply for certain sets of queries in the mixin.

This immediately reminded me of a conversation i had yesterday with @rgeyer (who joined halfway through the hack session, yay!) about how one of the first kinds of parameters we might experiment with typing would be for promql label matchers. I decided that instead of just going through and doing essentially the same hand conversion i did with cert-manager last week, i'd treat this serendipitous timing as a sign that i should explore creating a structure specifically for parameterizing promql label matcher.

I am suuuuper glad i did. This was a _really_ informative exercise. It:

* Viscerally illustrated how the design approach in CUE is very different than in jsonnet
* Made quite tangible how formalizing a structure around label matchers, rather than just doing pure string interpolation, is a stepping stone to doing more with queries (@brancz, this felt like it hit squarely on the long conversation we had back in Feb)
* Just felt really, really obvious how powerful a structure like this would be
* Illustrated the sort of design considerations that pop authors will clearly need to take into account

I didn't get around to writing the part of this that would actually make the something we could interpolate into an actual promql query. That's OK, though - can always look at that in the future.

The recording of the hack session is [here](https://drive.google.com/file/d/1Gp-TaiwYzA6tlb4Kyhv8dJP7AVP8EUfB/view?usp=sharing). (Sorry, we'll be switching to youtube uploads soon!). i start actually pursuing this around 10 minutes in, and @rgeyer joins around 31m.