### PR TITLE
Add rudimentary Prometheus rule and alert scuemata

### DIFF
--- a/cue.mod/pkg/github.com/prometheus/prometheus/schema/alert.cue
+++ b/cue.mod/pkg/github.com/prometheus/prometheus/schema/alert.cue
@@ -5,8 +5,17 @@ import "github.com/grafana/grafana/cue/scuemata"
 Alert: scuemata.#Family & {
     lineages: [
         [
-            {
-                placeholder: string
+            { // 0.0
+                // TODO docs
+                alert: string
+                // TODO docs
+                expr: string
+                // TODO docs
+                "for": string
+                // TODO docs
+                labels: [string]: string
+                // TODO docs
+                annotations: [string]: string
             }
         ]
     ]

--- a/cue.mod/pkg/github.com/prometheus/prometheus/schema/rule.cue
+++ b/cue.mod/pkg/github.com/prometheus/prometheus/schema/rule.cue
@@ -5,8 +5,15 @@ import "github.com/grafana/grafana/cue/scuemata"
 Rule: scuemata.#Family & {
     lineages: [
         [
-            {
-                placeholder: string
+            { // 0.0
+                // TODO docs
+                expr: string
+                // TODO docs
+                "for": string
+                // TODO docs
+                labels: [string]: string
+                // TODO docs
+                annotations: [string]: string
             }
         ]
     ]


### PR DESCRIPTION
This introduces a really basic first pass at defining scuemata for Prometheus rules and alerts. Having these scuemata is prerequisite to being able to actually set up meaningful CI on the examples/pops in this repo - without them, we're not actually validating anything at all about the rules and alerts contained in those pops.

i...really don't know where to check and verify that these schema actually complete representations of what Prometheus allows in its rules and alerts, or if there's any stricter constraints than `string` that could be applied which would better reflect the constraints imposed by Prometheus itself. But this at least gets something we can iterate on into place!

(This was the product of the community hack session from Aug 3 - thanks to @rgeyer and @matthewnolf for coming and asking all your great questions!)

Fixes #16